### PR TITLE
Remove layer flattening else to improve coverage

### DIFF
--- a/lib/neurx/structures/network.ex
+++ b/lib/neurx/structures/network.ex
@@ -93,11 +93,7 @@ defmodule Neurx.Network do
   end
 
   defp flatten_layers(network) do
-    if network.hidden_layers != nil do
-      [network.input_layer] ++ network.hidden_layers ++ [network.output_layer]
-    else
-      [network.input_layer] ++ [network.output_layer]
-    end
+    [network.input_layer] ++ network.hidden_layers ++ [network.output_layer]
   end
 
   @doc """


### PR DESCRIPTION
nil doesn't happen ever due to the hidden_neurons() function
https://github.com/NeurX/neurx/blob/a8e2e1f3cad32e519ed4125115d57028ae379416/lib/neurx/structures/network.ex#L56-L69

at the initial build, if hidden layers are nil, then it returns an empty list