### PR TITLE
Add functionality for error rate based training

### DIFF
--- a/lib/neurx/endpoints/train.ex
+++ b/lib/neurx/endpoints/train.ex
@@ -5,60 +5,76 @@ defmodule Neurx.Train do
 
   alias Neurx.{Network}
 
-  @default_epoch 0
-  @default_log_freq 0
+  @default_error 0.01
+  @default_log_freq 100
 
   @doc """
   Trains the network.
   """
   def train(network_pid, training_data, options) do
-    {epochs, log_freq} =
+    filtered_options =
       case options do
         nil ->
-          {@default_epoch, @default_log_freq}
+          %{epochs: nil, error_threshold: @default_error, log_freq: @default_log_freq}
         %{} ->
-          epochs = 
-            case options.epochs do
-              nil ->
-                @default_epoch
-              x when x <= 0 ->
-                @default_epoch
-              _ ->
-                options.epochs
-            end
-          log_freq = 
-            case options.log_freq do
-              nil ->
-                @default_log_freq
-              x when x <= 0 ->
-                @default_log_freq
-              _ ->
-                options.log_freq
-            end
-          {epochs, log_freq}
+          epochs =
+            Map.get(options, :epochs, -1)
+            |> (fn(x) -> if x <= 0, do: nil, else: x end).()
+
+          error_threshold =
+            Map.get(options, :error_threshold, -1)
+            |> (fn(x) -> if x <= 0, do: nil, else: x end).()
+
+          log_freq =
+            Map.get(options, :log_freq, @default_log_freq)
+            |>(fn(x) -> if x < 0, do: @default_log_freq, else: x end).()
+          %{epochs: epochs, error_threshold: error_threshold, log_freq: log_freq}
         _ ->
-          {@default_epoch, @default_log_freq}
+          %{epochs: nil, error_threshold: @default_error, log_freq: @default_log_freq}
       end
 
-    num_training_samples = length(training_data)
-    IO.puts "\n"
+    if (filtered_options.log_freq > 0), do: IO.puts("\n")
 
-    for epoch <- 0..epochs do
-      average_error =
-        Enum.reduce(training_data, 0, fn sample, sum ->
+    do_training(network_pid, training_data, filtered_options, length(training_data), 0)
+  end
+
+  defp do_training(network_pid, training_data, options, num_training_samples, epoch) do
+    # IO.inspect(options)
+    # IO.inspect(options.error_threshold)
+
+    average_error =
+      Enum.reduce(training_data, 0,
+        fn sample, sum ->
           network_pid |> Network.get() |> Network.activate(sample.input)
           network_pid |> Network.get() |> Network.train(sample.output)
-
           sum + Network.get(network_pid).error / num_training_samples
-        end)
+      end)
 
-      if log_freq != 0 && (rem(epoch, log_freq) == 0 || epoch + 1 == epochs) do
-        IO.puts("Epoch: #{epoch}    Error: #{unexponential(average_error)}")
-      end
+    if options.log_freq != 0 && (rem(epoch, options.log_freq) == 0 || epoch + 1 == options.epochs) do
+      IO.puts("Epoch: #{epoch}    Error: #{unexponential(average_error)}")
     end
 
-    {:ok, network_pid, Network.get(network_pid).error}
+    if (options.log_freq > 0) do
+
+    end
+    cond do
+      (options.error_threshold != nil) and (average_error <= options.error_threshold) ->
+        if (options.log_freq > 0) do
+          IO.inspect("END on ERROR")
+          IO.puts("Epoch: #{epoch}    Error: #{unexponential(average_error)}")
+        end
+        {:ok, network_pid, Network.get(network_pid).error}
+      (options.epochs != nil) and (epoch >= options.epochs) ->
+        if (options.log_freq > 0) do
+          IO.inspect("END on EPOCHS")
+          IO.puts("Epoch: #{epoch}    Error: #{unexponential(average_error)}")
+        end
+        {:ok, network_pid, Network.get(network_pid).error}
+      true ->
+        do_training(network_pid, training_data, options, num_training_samples, epoch+1)
+    end
   end
+
 
   defp unexponential(average_error) do
     :erlang.float_to_binary(average_error, [{:decimals, 19}, :compact])

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Neurx.MixProject do
   use Mix.Project
 
-  @version "0.1.3"
+  @version "0.1.4"
 
   def project do
     [

--- a/test/neurx/endpoints/train_test.exs
+++ b/test/neurx/endpoints/train_test.exs
@@ -4,7 +4,7 @@ defmodule TrainTest do
 
   Code.require_file("test/test_data.exs")
   alias Neurx.{Network, Layer, Neuron, Activators, LossFunctions, Optimizers}
-  
+
   ###############################################
   # Train Endpoint Tests
   ###############################################
@@ -17,7 +17,7 @@ defmodule TrainTest do
       RuntimeError -> nil
     end
   end
-  
+
   test "PID with Nil Data" do
     try do
       # Don't need to actual pass a PID.
@@ -27,7 +27,7 @@ defmodule TrainTest do
       RuntimeError -> nil
     end
   end
-  
+
   test "Data with Nil PID" do
     try do
       Neurx.train(nil, %{}, nil)
@@ -36,7 +36,7 @@ defmodule TrainTest do
       RuntimeError -> nil
     end
   end
-  
+
   test "Nil options" do
     try do
       # This will fail because the PID is invalid, only need to test options.
@@ -47,7 +47,7 @@ defmodule TrainTest do
     end
   end
 
-  test "Testing network training with no hidden layers" do
+  test "Testing network training with no hidden layers and invalid training options" do
     # Building the network.
     nn = Neurx.build(%{
       input_layer: 3,
@@ -94,7 +94,7 @@ defmodule TrainTest do
       assert(neuron.activation_fn == nil)
       assert(neuron.learning_rate == 0.1)
     end)
-    
+
     Enum.each(output_layer.neurons, fn pid ->
       neuron = Neuron.get(pid)
       assert(neuron)
@@ -104,17 +104,14 @@ defmodule TrainTest do
 
     # Training on simple dataset.
     data = TestData.get_simple_training_data()
-    options = %{
-      epochs: 1000,
-      log_freq: 100
-    }
+    options = 0
     {tnn, final_error} = Neurx.train(nn, data, options)
 
     assert(tnn)
     assert(final_error)
     assert(final_error < 0.01)
   end
-  
+
   test "Testing network training with one hidden layers" do
     # Building the network.
     nn = Neurx.build(%{
@@ -167,7 +164,7 @@ defmodule TrainTest do
       assert(neuron.activation_fn == nil)
       assert(neuron.learning_rate == 0.1)
     end)
-    
+
     Enum.each(network.hidden_layers, fn lpid ->
       layer = Layer.get(lpid)
       assert(layer)
@@ -185,7 +182,7 @@ defmodule TrainTest do
         end
       end)
     end)
-    
+
     Enum.each(output_layer.neurons, fn pid ->
       neuron = Neuron.get(pid)
       assert(neuron)
@@ -197,6 +194,189 @@ defmodule TrainTest do
     data = TestData.get_simple_training_data()
     options = %{
       epochs: 1000,
+      log_freq: 100
+    }
+    {tnn, final_error} = Neurx.train(nn, data, options)
+
+    assert(tnn)
+    assert(final_error)
+    assert(final_error < 0.01)
+  end
+
+  test "Testing network training Error Threshold" do
+    # Building the network.
+    nn = Neurx.build(%{
+      input_layer: 3,
+      output_layer: %{
+        size: 1
+      },
+      hidden_layers: [
+        %{
+          size: 2
+        }
+      ]
+    })
+
+    assert(nn)
+
+    network = Network.get(nn)
+
+    assert(network)
+    assert(network.input_layer)
+    assert(network.output_layer)
+    assert(length(network.hidden_layers) == 1)
+
+    input_layer = Layer.get(network.input_layer)
+    output_layer = Layer.get(network.output_layer)
+
+    sigmoid = Activators.getFunction("Sigmoid")
+    mse = LossFunctions.getFunction("MSE")
+    sgd = Optimizers.getFunction("SGD")
+    assert(sigmoid)
+    assert(mse)
+    assert(sgd)
+
+    assert(network.loss_fn == mse)
+    assert(network.optim_fn == sgd)
+
+    assert(input_layer)
+    assert(length(input_layer.neurons) == 3 + 1)
+    assert(input_layer.activation_fn == nil)
+    assert(input_layer.optim_fn == sgd)
+
+    assert(output_layer)
+    assert(length(output_layer.neurons) == 1)
+    assert(output_layer.activation_fn == sigmoid)
+    assert(output_layer.optim_fn == sgd)
+
+    Enum.each(input_layer.neurons, fn pid ->
+      neuron = Neuron.get(pid)
+      assert(neuron)
+      assert(neuron.activation_fn == nil)
+      assert(neuron.learning_rate == 0.1)
+    end)
+
+    Enum.each(network.hidden_layers, fn lpid ->
+      layer = Layer.get(lpid)
+      assert(layer)
+      assert(length(layer.neurons) == 3)
+      assert(layer.activation_fn == sigmoid)
+      Enum.each(layer.neurons, fn npid ->
+        neuron = Neuron.get(npid)
+        assert(neuron)
+        assert(neuron.learning_rate == 0.1)
+        assert(neuron.optim_fn == sgd)
+        if neuron.bias? do
+          assert(neuron.activation_fn == nil)
+        else
+          assert(neuron.activation_fn == sigmoid)
+        end
+      end)
+    end)
+
+    Enum.each(output_layer.neurons, fn pid ->
+      neuron = Neuron.get(pid)
+      assert(neuron)
+      assert(neuron.activation_fn == sigmoid)
+      assert(neuron.learning_rate == 0.1)
+    end)
+
+    # Training on simple dataset.
+    data = TestData.get_simple_training_data()
+    options = %{
+      error_threshold: 0.002,
+      log_freq: 100
+    }
+    {tnn, final_error} = Neurx.train(nn, data, options)
+
+    assert(tnn)
+    assert(final_error)
+    assert(final_error < 0.01)
+  end
+
+  test "Testing network training Epochs and Error Threshold" do
+    # Building the network.
+    nn = Neurx.build(%{
+      input_layer: 3,
+      output_layer: %{
+        size: 1
+      },
+      hidden_layers: [
+        %{
+          size: 2
+        }
+      ]
+    })
+
+    assert(nn)
+
+    network = Network.get(nn)
+
+    assert(network)
+    assert(network.input_layer)
+    assert(network.output_layer)
+    assert(length(network.hidden_layers) == 1)
+
+    input_layer = Layer.get(network.input_layer)
+    output_layer = Layer.get(network.output_layer)
+
+    sigmoid = Activators.getFunction("Sigmoid")
+    mse = LossFunctions.getFunction("MSE")
+    sgd = Optimizers.getFunction("SGD")
+    assert(sigmoid)
+    assert(mse)
+    assert(sgd)
+
+    assert(network.loss_fn == mse)
+    assert(network.optim_fn == sgd)
+
+    assert(input_layer)
+    assert(length(input_layer.neurons) == 3 + 1)
+    assert(input_layer.activation_fn == nil)
+    assert(input_layer.optim_fn == sgd)
+
+    assert(output_layer)
+    assert(length(output_layer.neurons) == 1)
+    assert(output_layer.activation_fn == sigmoid)
+    assert(output_layer.optim_fn == sgd)
+
+    Enum.each(input_layer.neurons, fn pid ->
+      neuron = Neuron.get(pid)
+      assert(neuron)
+      assert(neuron.activation_fn == nil)
+      assert(neuron.learning_rate == 0.1)
+    end)
+
+    Enum.each(network.hidden_layers, fn lpid ->
+      layer = Layer.get(lpid)
+      assert(layer)
+      assert(length(layer.neurons) == 3)
+      assert(layer.activation_fn == sigmoid)
+      Enum.each(layer.neurons, fn npid ->
+        neuron = Neuron.get(npid)
+        assert(neuron)
+        assert(neuron.learning_rate == 0.1)
+        assert(neuron.optim_fn == sgd)
+        if neuron.bias? do
+          assert(neuron.activation_fn == nil)
+        else
+          assert(neuron.activation_fn == sigmoid)
+        end
+      end)
+    end)
+
+    Enum.each(output_layer.neurons, fn pid ->
+      neuron = Neuron.get(pid)
+      assert(neuron)
+      assert(neuron.activation_fn == sigmoid)
+      assert(neuron.learning_rate == 0.1)
+    end)
+
+    # Training on simple dataset.
+    data = TestData.get_simple_training_data()
+    options = %{
+      epochs: 3000,
+      error_threshold: 0.002,
       log_freq: 100
     }
     {tnn, final_error} = Neurx.train(nn, data, options)


### PR DESCRIPTION
On training phase, you can specify an epoch and/or a error rate.  It will then train until one of the two specified is met.  If it is failed to be specified or it is an invalid option, the default error rate of 0.01 must be reached.